### PR TITLE
Convert map outputs to lists for Python3 support

### DIFF
--- a/pytorch_segmentation_detection/datasets/NYUv2Segmentation.py
+++ b/pytorch_segmentation_detection/datasets/NYUv2Segmentation.py
@@ -49,8 +49,8 @@ class NYUv2Segmentation(data.Dataset):
         images_filenames = sorted(os.listdir(images_folder_path))
         annotations_filenames = sorted(os.listdir(annotations_folder_path))
 
-        self.images_filenames = map(lambda x: os.path.join(images_folder_path, x), images_filenames)
-        self.annotations_filenames = map(lambda x: os.path.join(annotations_folder_path, x), annotations_filenames)
+        self.images_filenames = list(map(lambda x: os.path.join(images_folder_path, x), images_filenames))
+        self.annotations_filenames = list(map(lambda x: os.path.join(annotations_folder_path, x), annotations_filenames))
             
     def __len__(self):
 

--- a/pytorch_segmentation_detection/datasets/cityscapes.py
+++ b/pytorch_segmentation_detection/datasets/cityscapes.py
@@ -23,7 +23,7 @@ class Cityscapes(data.Dataset):
     # in the annotation images into train labels
     # Some variables in the annotatio are ignore for example
     # See utils.cityscapes for more details
-    ordered_train_labels = np.asarray( map(lambda x: x.trainId, cityscapes_labels) )
+    ordered_train_labels = np.asarray( list(map(lambda x: x.trainId, cityscapes_labels)) )
     
     number_of_classes = 19
 

--- a/pytorch_segmentation_detection/datasets/detection/pascal_voc.py
+++ b/pytorch_segmentation_detection/datasets/detection/pascal_voc.py
@@ -79,8 +79,8 @@ class PascalVOCDetection(data.Dataset):
         
         pil_img, cocolike_detection_annotations = self.pascal_cocolike_db[idx]
         
-        bboxes_locations_topleft_xywh = map(lambda cocolike_dict: cocolike_dict['bbox'], cocolike_detection_annotations)
-        bboxes_classes = map(lambda cocolike_dict: cocolike_dict['category_id'], cocolike_detection_annotations)
+        bboxes_locations_topleft_xywh = list(map(lambda cocolike_dict: cocolike_dict['bbox'], cocolike_detection_annotations))
+        bboxes_classes = list(map(lambda cocolike_dict: cocolike_dict['category_id'], cocolike_detection_annotations))
         
         # Getting the xywh coordinates and converting them to xyxy
         bboxes_locations_topleft_xywh = torch.FloatTensor( bboxes_locations_topleft_xywh )

--- a/pytorch_segmentation_detection/datasets/endovis_instrument_2017.py
+++ b/pytorch_segmentation_detection/datasets/endovis_instrument_2017.py
@@ -143,8 +143,8 @@ class Endovis_Instrument_2017(data.Dataset):
 
             for instrument_type in dataset_annotations_dict:
 
-                current_instrument_full_groundtruth_foldernames = map(lambda x: os.path.join(dataset_annotations_path, x),
-                                                                      dataset_annotations_dict[instrument_type] )
+                current_instrument_full_groundtruth_foldernames = list(map(lambda x: os.path.join(dataset_annotations_path, x),
+                                                                           dataset_annotations_dict[instrument_type]))
 
                 dataset_annotations_dict[instrument_type] = current_instrument_full_groundtruth_foldernames
                 
@@ -220,7 +220,7 @@ class Endovis_Instrument_2017(data.Dataset):
 
             current_left_right_foldernames = current_names_to_groundtruth_mapping[instrument_name]
 
-            current_left_right_filenames = map(lambda x: get_sorted_by_name_image_names(x), current_left_right_foldernames)
+            current_left_right_filenames = list(map(lambda x: get_sorted_by_name_image_names(x), current_left_right_foldernames))
 
             current_number_of_frames = len(current_left_right_filenames[0])
 
@@ -234,7 +234,7 @@ class Endovis_Instrument_2017(data.Dataset):
             # In case when there is just one instrument of a particular type,
             # we will have a tuple of size one
             # We also convert the tuple to lists outright using map
-            current_instrument_annotation_filenames = map(list, zip(*current_left_right_filenames))
+            current_instrument_annotation_filenames = list(map(list, zip(*current_left_right_filenames)))
 
             for index, current_dict in enumerate(overall_list):
 
@@ -274,10 +274,10 @@ class Endovis_Instrument_2017(data.Dataset):
             current_left_right_filenames_pair = annotations_dict[instrument_name]
 
             # Read all the annotation images
-            current_left_right_numpy_pair = map(io.imread, current_left_right_filenames_pair)
+            current_left_right_numpy_pair = list(map(io.imread, current_left_right_filenames_pair))
             
             # Some annotation files has 2 dims, some 3 dims. Making it consistent here
-            current_left_right_numpy_pair = map(self.remove_third_dim_in_annotation_file, current_left_right_numpy_pair)
+            current_left_right_numpy_pair = list(map(self.remove_third_dim_in_annotation_file, current_left_right_numpy_pair))
             
             # Merge all the annotation labels into one annotation image
             current_merged_numpy = reduce(lambda x, y: merge_left_and_right_annotations_v2(x, y, self.parts_class_labels[1:]),

--- a/pytorch_segmentation_detection/utils/pascal_voc.py
+++ b/pytorch_segmentation_detection/utils/pascal_voc.py
@@ -98,7 +98,7 @@ def readlines_with_strip(filename):
         lines = f.readlines()
 
     # Clean filenames from whitespaces and newline symbols
-    clean_lines = map(lambda x: x.strip(), lines)
+    clean_lines = list(map(lambda x: x.strip(), lines))
     
     return clean_lines
 
@@ -118,7 +118,7 @@ def readlines_with_strip_array_version(filenames_array):
         Strings that were read from the file and cleaned up.
     """
     
-    multiple_files_clean_lines = map(readlines_with_strip, filenames_array)
+    multiple_files_clean_lines = list(map(readlines_with_strip, filenames_array))
     
     return multiple_files_clean_lines
 
@@ -141,7 +141,7 @@ def add_full_path_and_extention_to_filenames(filenames_array, full_path, extenti
     full_filenames : array of strings
         updated array with filenames
     """
-    full_filenames = map(lambda x: os.path.join(full_path, x) + '.' + extention, filenames_array)
+    full_filenames = list(map(lambda x: os.path.join(full_path, x) + '.' + extention, filenames_array))
     
     return full_filenames
 
@@ -162,8 +162,8 @@ def add_full_path_and_extention_to_filenames_array_version(filenames_array_array
     full_filenames : array of array of strings
         updated array of array with filenames
     """
-    result = map(lambda x: add_full_path_and_extention_to_filenames(x, full_path, extention),
-                 filenames_array_array)
+    result = list(map(lambda x: add_full_path_and_extention_to_filenames(x, full_path, extention),
+                      filenames_array_array))
     
     return result
 
@@ -216,7 +216,7 @@ def get_pascal_segmentation_image_annotation_filenames_pairs(pascal_root):
     # so that we have pairs of respective image plus annotation
     # [[(pair_1), (pair_1), ..], [(pair_1), (pair_2), ..] ..]
     # Overall, we have 3 elements -- representing train/val/trainval datasets
-    image_annotation_filename_pairs = map(lambda x: list(zip(*x)), temp)
+    image_annotation_filename_pairs = list(map(lambda x: list(zip(*x)), temp))
     
     return image_annotation_filename_pairs
 
@@ -377,7 +377,7 @@ def get_pascal_berkeley_augmented_segmentation_image_annotation_filenames_pairs(
     # so that we have pairs of respective image plus annotation
     # [[(pair_1), (pair_1), ..], [(pair_1), (pair_2), ..] ..]
     # Overall, we have 3 elements -- representing train/val/trainval datasets
-    image_annotation_filename_pairs = map(lambda x: list(zip(*x)), temp)
+    image_annotation_filename_pairs = list(map(lambda x: list(zip(*x)), temp))
     
     return image_annotation_filename_pairs
 
@@ -517,8 +517,8 @@ def get_augmented_pascal_image_annotation_filename_pairs(pascal_root, pascal_ber
     pascal_name_lists = readlines_with_strip_array_version(pascal_txts)
     berkeley_name_lists = readlines_with_strip_array_version(berkeley_txts)
 
-    pascal_train_name_set, pascal_val_name_set, _ = map(lambda x: set(x), pascal_name_lists)
-    berkeley_train_name_set, berkeley_val_name_set = map(lambda x: set(x), berkeley_name_lists)
+    pascal_train_name_set, pascal_val_name_set, _ = list(map(lambda x: set(x), pascal_name_lists))
+    berkeley_train_name_set, berkeley_val_name_set = list(map(lambda x: set(x), berkeley_name_lists))
 
     all_berkeley = berkeley_train_name_set | berkeley_val_name_set
     all_pascal = pascal_train_name_set | pascal_val_name_set


### PR DESCRIPTION
Hey Daniil, thanks for your work on this repo. 

I noticed that some places in the code use the output of the map function directly, which is a problem for Python3 since the function returns a map object instead of a list. I've just gone ahead and converted instances of map object to list in a bunch of places -- I noticed you did this for some files already, but it's currently breaking the cityscapes dataset, which I'm currently trying to use :-) 

The Python2 [docs](https://docs.python.org/2/library/functions.html#map) guarantee the result of map is always a list so I assume this shouldn't break anything.